### PR TITLE
Connect to mongo db 4.0.x using mongoose 5.7.0

### DIFF
--- a/packages/strapi-hook-mongoose/lib/index.js
+++ b/packages/strapi-hook-mongoose/lib/index.js
@@ -56,6 +56,7 @@ module.exports = function(strapi) {
           password,
           database,
           srv,
+          useUnifiedTopology
         } = connection.settings;
 
         const uriOptions = uri ? url.parse(uri, true).query : {};
@@ -85,6 +86,7 @@ module.exports = function(strapi) {
         connectOptions.useNewUrlParser = true;
         connectOptions.dbName = database;
         connectOptions.useCreateIndex = true;
+        connectOptions.useUnifiedTopology = useUnifiedTopology || 'false';
 
         try {
           /* FIXME: for now, mongoose doesn't support srv auth except the way including user/pass in URI.


### PR DESCRIPTION
Added support for connection setting useUnifiedTopology so it can be positioned via the database.json file in strapi project. By default it is positioned to false.
If this is not set and you are connecting to a mongo db v4.0.x using the beta-16.1 and higher version of the strapi-hook-mongoose you will get the following warning message when starting the strapi server:
DeprecationWarning: current Server Discovery and Monitoring engine is
deprecated, and will be removed in a future version. To use the new Server
Discover and Monitoring engine, pass option { useUnifiedTopology: true } to
the MongoClient constructor.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

<!--
Replace [ ] by [x] to check these checkboxes!
-->

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [ ] Framework
- [X] Plugin

#### Manual testing done on the following databases:

- [ ] Not applicable
- [X] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
