### PR TITLE
Adding Cloudfront option to AWS S3 upload provider

### DIFF
--- a/packages/strapi-provider-upload-aws-s3/lib/index.js
+++ b/packages/strapi-provider-upload-aws-s3/lib/index.js
@@ -52,6 +52,18 @@ module.exports = {
       label: 'Bucket',
       type: 'text',
     },
+    cloudfrontIsEnabled: {
+      label: 'Enable Cloudfront',
+      type: 'enum',
+      values: [
+        'Yes',
+        'No'
+      ],
+    },
+    cloudfrontURL: {
+      label: 'Cloudfront URL (only considered if Cloudfront is Enabled)',
+      type: 'text'
+    },
   },
   init: config => {
     // configure AWS S3 bucket connection
@@ -86,7 +98,12 @@ module.exports = {
               }
 
               // set the bucket file url
-              file.url = data.Location;
+              if (trimParam(config.cloudfrontIsEnabled) === "Yes")
+                // with Cloudfront is enabled
+                file.url = config.cloudfrontURL + "/" + data.key;
+              else
+                // or the s3 bucket public URL
+                file.url = data.Location;
 
               resolve();
             }


### PR DESCRIPTION
#### Description of what you did:

Related to issue [#3218](https://github.com/strapi/strapi/issues/3218)

Updating provider configuration in order to be able to enable Cloudfront delivery for uploaded assets to s3 bucket. This configuration add a Yes / No dropdown to indicate if we wish to store the Cloudfront URL (which is the other configurable field) of the uploaded asset instead of the S3 bucket URL. This entails that the user has already created a Cloudfront distribution for his/her s3 bucket.

Configuration screen looks like this with the two extra fields for Cloudfront: 

![image](https://user-images.githubusercontent.com/4890827/74341878-d022af80-4da8-11ea-8df9-5f4e9842e559.png)


#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [X] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [ ] Documentation
- [X] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [X] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite
